### PR TITLE
Only cache 'status 200' requests

### DIFF
--- a/jpcache-main.php
+++ b/jpcache-main.php
@@ -351,6 +351,8 @@
      */
     function jpcache_end($contents)
     {
+        global $pretext;
+
         jpcache_debug("Callback happened");
 
         // We do a binary comparison of the first two bytes, see
@@ -366,7 +368,8 @@
         if ((connection_aborted() ) || 
             ($GLOBALS["JPCACHE_ON"] == 0) || 
             ($GLOBALS["JPCACHE_TIME"] <= 0) || 
-			( (strlen($contents)/(1+($is_gzipped*2))) < 50 ) )
+            ( (strlen($contents)/(1+($is_gzipped*2))) < 50 ) ||
+            $pretext['status'] != 200 )
         {
   			jpcache_debug("Skipped writing Cachefile. Returned as is.");
             return $contents;


### PR DESCRIPTION
There is a problem with 404 errors (and other errors) when you cache them: They are served as status 200.
